### PR TITLE
[Imported] Removing unused path parameter

### DIFF
--- a/solutions/system_design/social_graph/README.md
+++ b/solutions/system_design/social_graph/README.md
@@ -190,7 +190,7 @@ class UserGraphService(object):
             # Reverse the list since we iterated backwards
             return path_ids[::-1]
 
-    def _shortest_path(self, source_key, dest_key, path):
+    def _shortest_path(self, source_key, dest_key):
         # Use the id to get the Person
         source = self.person(source_key)
         # Update our bfs queue


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#1030](https://github.com/donnemartin/system-design-primer/pull/1030)**

Original author: @ms5914

---

The path parameter is not used in the function.
