### PR TITLE
[Imported] fix: correct time unit to `min`

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,17 +541,17 @@ Availability is often quantified by uptime (or downtime) as a percentage of time
 | Duration            | Acceptable downtime|
 |---------------------|--------------------|
 | Downtime per year   | 8h 45min 57s       |
-| Downtime per month  | 43m 49.7s          |
-| Downtime per week   | 10m 4.8s           |
-| Downtime per day    | 1m 26.4s           |
+| Downtime per month  | 43min 49.7s          |
+| Downtime per week   | 10min 4.8s           |
+| Downtime per day    | 1min 26.4s           |
 
 #### 99.99% availability - four 9s
 
 | Duration            | Acceptable downtime|
 |---------------------|--------------------|
 | Downtime per year   | 52min 35.7s        |
-| Downtime per month  | 4m 23s             |
-| Downtime per week   | 1m 5s              |
+| Downtime per month  | 4min 23s             |
+| Downtime per week   | 1min 5s              |
 | Downtime per day    | 8.6s               |
 
 #### Availability in parallel vs in sequence


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#853](https://github.com/donnemartin/system-design-primer/pull/853)**

Original author: @felix-seifert

---

`m` is the unit abbreviation for metres. For minutes, we should use `min` consistently.
