### PR TITLE
[Imported] Add cheatsheet on common approximations, numbers, and conversions for system design

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ You might be asked to do some estimates by hand.  Refer to the [Appendix](#appen
 * [Use back of the envelope calculations](http://highscalability.com/blog/2011/1/26/google-pro-tip-use-back-of-the-envelope-calculations-to-choo.html)
 * [Powers of two table](#powers-of-two-table)
 * [Latency numbers every programmer should know](#latency-numbers-every-programmer-should-know)
+* [Cheatsheet System Design Numbers and Approximations](https://github.com/bschauerte/System-Design-Numbers-and-Approximations)
 
 ### Source(s) and further reading
 


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#660](https://github.com/donnemartin/system-design-primer/pull/660)**

Original author: @bschauerte

---

Added a link to a cheatsheet for system design numbers (latencies, ...) and approximations

