### PR TITLE
[Imported] Update Atlassian's engineering blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1751,7 +1751,7 @@ Handy metrics based on numbers above:
 > Questions you encounter might be from the same domain.
 
 * [Airbnb Engineering](http://nerds.airbnb.com/)
-* [Atlassian Developers](https://developer.atlassian.com/blog/)
+* [Atlassian Developers](https://www.atlassian.com/blog/atlassian-engineering)
 * [AWS Blog](https://aws.amazon.com/blogs/aws/)
 * [Bitly Engineering Blog](http://word.bitly.com/)
 * [Box Blogs](https://blog.box.com/blog/category/engineering)


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#620](https://github.com/donnemartin/system-design-primer/pull/620)**

Original author: @raul1991

---

The previous url (https://developer.atlassian.com/blog/) points to more general announcements/events happening across Atlassian. Therefore, I've changed the url to (https://www.atlassian.com/blog/atlassian-engineering) which points to the real engineering related problems.
