### PR TITLE
[Imported] zh-Hans:change some of the links of solutions from README.md to README-zh-Hans.md in Chinese translation

### DIFF
--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -246,10 +246,10 @@
 
 ### 第三步：设计核心组件
 
-对每一个核心组件进行详细深入的分析。举例来说，如果你被问到[设计一个 url 缩写服务](solutions/system_design/pastebin/README.md)，开始讨论：
+对每一个核心组件进行详细深入的分析。举例来说，如果你被问到[设计一个 url 缩写服务](solutions/system_design/pastebin/README-zh-Hans.md)，开始讨论：
 
 * 生成并储存一个完整 url 的 hash
-    * [MD5](solutions/system_design/pastebin/README.md) 和 [Base62](solutions/system_design/pastebin/README.md)
+    * [MD5](solutions/system_design/pastebin/README-zh-Hans.md) 和 [Base62](solutions/system_design/pastebin/README-zh-Hans.md)
     * Hash 碰撞
     * SQL 还是 NoSQL
     * 数据库模型
@@ -294,60 +294,60 @@
 | 问题                                       |                                          |
 | ---------------------------------------- | ---------------------------------------- |
 | 设计 Pastebin.com (或者 Bit.ly)              | [解答](solutions/system_design/pastebin/README-zh-Hans.md) |
-| 设计 Twitter 时间线和搜索 (或者 Facebook feed 和搜索) | [解答](solutions/system_design/twitter/README.md) |
-| 设计一个网页爬虫                                 | [解答](solutions/system_design/web_crawler/README.md) |
-| 设计 Mint.com                              | [解答](solutions/system_design/mint/README.md) |
-| 为一个社交网络设计数据结构                            | [解答](solutions/system_design/social_graph/README.md) |
-| 为搜索引擎设计一个 key-value 储存                   | [解答](solutions/system_design/query_cache/README.md) |
-| 通过分类特性设计 Amazon 的销售排名                    | [解答](solutions/system_design/sales_rank/README.md) |
-| 在 AWS 上设计一个百万用户级别的系统                     | [解答](solutions/system_design/scaling_aws/README.md) |
+| 设计 Twitter 时间线和搜索 (或者 Facebook feed 和搜索) | [解答](solutions/system_design/twitter/README-zh-Hans.md) |
+| 设计一个网页爬虫                                 | [解答](solutions/system_design/web_crawler/README-zh-Hans.md) |
+| 设计 Mint.com                              | [解答](solutions/system_design/mint/README-zh-Hans.md) |
+| 为一个社交网络设计数据结构                            | [解答](solutions/system_design/social_graph/README-zh-Hans.md) |
+| 为搜索引擎设计一个 key-value 储存                   | [解答](solutions/system_design/query_cache/README-zh-Hans.md) |
+| 通过分类特性设计 Amazon 的销售排名                    | [解答](solutions/system_design/sales_rank/README-zh-Hans.md) |
+| 在 AWS 上设计一个百万用户级别的系统                     | [解答](solutions/system_design/scaling_aws/README-zh-Hans.md) |
 | 添加一个系统设计问题                               | [贡献](#贡献)                                |
 
 ### 设计 Pastebin.com (或者 Bit.ly)
 
-[查看实践与解答](solutions/system_design/pastebin/README.md)
+[查看实践与解答](solutions/system_design/pastebin/README-zh-Hans.md)
 
 ![Imgur](images/4edXG0T.png)
 
 ### 设计 Twitter 时间线和搜索 (或者 Facebook feed 和搜索)
 
-[查看实践与解答](solutions/system_design/twitter/README.md)
+[查看实践与解答](solutions/system_design/twitter/README-zh-Hans.md)
 
 ![Imgur](images/jrUBAF7.png)
 
 ### 设计一个网页爬虫
 
-[查看实践与解答](solutions/system_design/web_crawler/README.md)
+[查看实践与解答](solutions/system_design/web_crawler/README-zh-Hans.md)
 
 ![Imgur](images/bWxPtQA.png)
 
 ### 设计 Mint.com
 
-[查看实践与解答](solutions/system_design/mint/README.md)
+[查看实践与解答](solutions/system_design/mint/README-zh-Hans.md)
 
 ![Imgur](images/V5q57vU.png)
 
 ### 为一个社交网络设计数据结构
 
-[查看实践与解答](solutions/system_design/social_graph/README.md)
+[查看实践与解答](solutions/system_design/social_graph/README-zh-Hans.md)
 
 ![Imgur](images/cdCv5g7.png)
 
 ### 为搜索引擎设计一个 key-value 储存
 
-[查看实践与解答](solutions/system_design/query_cache/README.md)
+[查看实践与解答](solutions/system_design/query_cache/README-zh-Hans.md)
 
 ![Imgur](images/4j99mhe.png)
 
 ### 设计按类别分类的 Amazon 销售排名
 
-[查看实践与解答](solutions/system_design/sales_rank/README.md)
+[查看实践与解答](solutions/system_design/sales_rank/README-zh-Hans.md)
 
 ![Imgur](images/MzExP06.png)
 
 ### 在 AWS 上设计一个百万用户级别的系统
 
-[查看实践与解答](solutions/system_design/scaling_aws/README.md)
+[查看实践与解答](solutions/system_design/scaling_aws/README-zh-Hans.md)
 
 ![Imgur](images/jj3A5N8.png)
 


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#613](https://github.com/donnemartin/system-design-primer/pull/613)**

Original author: @knwng

---

Hi guys, I found out that some links of solutions in the chinese translation didn't link to its Chinese version but still the English one. So I change them from README.md to README-zh-Hans.md respectively.
