### PR TITLE
[Imported] Fix #493 : Correct mention of Protobuf in RPC frameworks with mention of gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1460,7 +1460,7 @@ Use UDP over TCP when:
   <i><a href=http://www.puncsky.com/blog/2016-02-13-crack-the-system-design-interview>Source: Crack the system design interview</a></i>
 </p>
 
-In an RPC, a client causes a procedure to execute on a different address space, usually a remote server.  The procedure is coded as if it were a local procedure call, abstracting away the details of how to communicate with the server from the client program.  Remote calls are usually slower and less reliable than local calls so it is helpful to distinguish RPC calls from local calls.  Popular RPC frameworks include [Protobuf](https://developers.google.com/protocol-buffers/), [Thrift](https://thrift.apache.org/), and [Avro](https://avro.apache.org/docs/current/).
+In an RPC, a client causes a procedure to execute on a different address space, usually a remote server.  The procedure is coded as if it were a local procedure call, abstracting away the details of how to communicate with the server from the client program.  Remote calls are usually slower and less reliable than local calls so it is helpful to distinguish RPC calls from local calls.  Popular RPC frameworks include [gRPC](https://grpc.io) (extensively used in combination with [Protobuf](https://developers.google.com/protocol-buffers/) as the serialization mechanism), [Thrift](https://thrift.apache.org/), and [Avro](https://avro.apache.org/docs/current/).
 
 RPC is a request-response protocol:
 


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#494](https://github.com/donnemartin/system-design-primer/pull/494)**

Original author: @aymec

---

See #493 
