### PR TITLE
[Imported] Latency numbers: remove conversion to throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -1623,10 +1623,6 @@ Notes
 
 Handy metrics based on numbers above:
 
-* Read sequentially from disk at 30 MB/s
-* Read sequentially from 1 Gbps Ethernet at 100 MB/s
-* Read sequentially from SSD at 1 GB/s
-* Read sequentially from main memory at 4 GB/s
 * 6-7 world-wide round trips per second
 * 2,000 round trips per second within a data center
 


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#427](https://github.com/donnemartin/system-design-primer/pull/427)**

Original author: @psanan

---

Remove conversion of latency numbers to throughput.

This is misleading for two reasons:
1. Latency and throughput are not computable from each other. For example: if I know it takes 1 second to turn on the hose, get 1 liter of water, and turn it off, I cannot conclude that the maximum rate I can get water out of the hose is 1 liter per second (though I can conclude it's more than that). 
2. The throughput estimates seem suspect, in and of themselves. These are great numbers to know, of course, but need to be backed by a separate source. (This'll be extra important if and when this guide includes information about, say, GPUs, which are optimized for throughput).
