### PR TITLE
[Imported] added queues.io to task queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,7 +1348,6 @@ Tasks queues receive tasks and their related data, runs them in background, then
 
 **[Celery](http://www.celeryproject.org/)** has support for scheduling and primarily has python support.
 
-**[Queues.io](http://queues.io/)** - Collection of all task queues and their info.
 
 ### Back pressure
 

--- a/README.md
+++ b/README.md
@@ -1344,9 +1344,11 @@ The user is not blocked and the job is processed in the background.  During this
 
 ### Task queues
 
-Tasks queues receive tasks and their related data, runs them, then delivers their results.  They can support scheduling and can be used to run computationally-intensive jobs in the background.
+Tasks queues receive tasks and their related data, runs them in background, then delivers their results.  They can support scheduling and can be used to run computationally-intensive jobs in the background.
 
-**Celery** has support for scheduling and primarily has python support.
+**[Celery](http://www.celeryproject.org/)** has support for scheduling and primarily has python support.
+
+**[Queues.io](http://queues.io/)** - Collection of all task queues and their info.
 
 ### Back pressure
 


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#330](https://github.com/donnemartin/system-design-primer/pull/330)**

Original author: @sureshdsk

---

Added queues.io to task queues section. It has a collection of all task queues across all languages. 
