### PR TITLE
[Imported] Cleanup obsolete CHAR vs VARCHAR note

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,8 +901,6 @@ Benchmarking and profiling might point you to the following optimizations.
 ##### Tighten up the schema
 
 * MySQL dumps to disk in contiguous blocks for fast access.
-* Use `CHAR` instead of `VARCHAR` for fixed-length fields.
-    * `CHAR` effectively allows for fast, random access, whereas with `VARCHAR`, you must find the end of a string before moving onto the next one.
 * Use `TEXT` for large blocks of text such as blog posts.  `TEXT` also allows for boolean searches.  Using a `TEXT` field results in storing a pointer on disk that is used to locate the text block.
 * Use `INT` for larger numbers up to 2^32 or 4 billion.
 * Use `DECIMAL` for currency to avoid floating point representation errors.


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#261](https://github.com/donnemartin/system-design-primer/pull/261)**

Original author: @0bsearch

---

This note is not valid for majority of modern RDBMS and modern storage engines.

`CHAR` does not guarantee "fixed size", nor fixed length improves random access — this is rare case for column storage engines.

`CHAR` is mostly supported to meet ANSI
