### PR TITLE
[Imported] Fix #86: Update powers of two table to binary prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1533,12 +1533,12 @@ Power           Exact Value         Approx Value        Bytes
 ---------------------------------------------------------------
 7                             128
 8                             256
-10                           1024   1 thousand           1 KB
-16                         65,536                       64 KB
-20                      1,048,576   1 million            1 MB
-30                  1,073,741,824   1 billion            1 GB
-32                  4,294,967,296                        4 GB
-40              1,099,511,627,776   1 trillion           1 TB
+10                           1024   1 thousand          1 KiB
+16                         65,536                      64 KiB
+20                      1,048,576   1 million           1 MiB
+30                  1,073,741,824   1 billion           1 GiB
+32                  4,294,967,296                       4 GiB
+40              1,099,511,627,776   1 trillion          1 TiB
 ```
 
 #### Source(s) and further reading
@@ -1555,22 +1555,22 @@ Branch mispredict                            5   ns
 L2 cache reference                           7   ns                      14x L1 cache
 Mutex lock/unlock                           25   ns
 Main memory reference                      100   ns                      20x L2 cache, 200x L1 cache
-Compress 1K bytes with Zippy            10,000   ns       10 us
-Send 1 KB bytes over 1 Gbps network     10,000   ns       10 us
-Read 4 KB randomly from SSD*           150,000   ns      150 us          ~1GB/sec SSD
-Read 1 MB sequentially from memory     250,000   ns      250 us
-Round trip within same datacenter      500,000   ns      500 us
-Read 1 MB sequentially from SSD*     1,000,000   ns    1,000 us    1 ms  ~1GB/sec SSD, 4X memory
-Disk seek                           10,000,000   ns   10,000 us   10 ms  20x datacenter roundtrip
-Read 1 MB sequentially from 1 Gbps  10,000,000   ns   10,000 us   10 ms  40x memory, 10X SSD
-Read 1 MB sequentially from disk    30,000,000   ns   30,000 us   30 ms 120x memory, 30X SSD
-Send packet CA->Netherlands->CA    150,000,000   ns  150,000 us  150 ms
+Compress 1K bytes with Zippy            10,000   ns       10 μs
+Send 1 KB bytes over 1 Gbps network     10,000   ns       10 μs
+Read 4 KB randomly from SSD*           150,000   ns      150 μs          ~1GB/sec SSD
+Read 1 MB sequentially from memory     250,000   ns      250 μs
+Round trip within same datacenter      500,000   ns      500 μs
+Read 1 MB sequentially from SSD*     1,000,000   ns    1,000 μs    1 ms  ~1GB/sec SSD, 4X memory
+Disk seek                           10,000,000   ns   10,000 μs   10 ms  20x datacenter roundtrip
+Read 1 MB sequentially from 1 Gbps  10,000,000   ns   10,000 μs   10 ms  40x memory, 10X SSD
+Read 1 MB sequentially from disk    30,000,000   ns   30,000 μs   30 ms 120x memory, 30X SSD
+Send packet CA->Netherlands->CA    150,000,000   ns  150,000 μs  150 ms
 
 Notes
 -----
 1 ns = 10^-9 seconds
-1 us = 10^-6 seconds = 1,000 ns
-1 ms = 10^-3 seconds = 1,000 us = 1,000,000 ns
+1 μs = 10^-6 seconds = 1,000 ns
+1 ms = 10^-3 seconds = 1,000 μs = 1,000,000 ns
 ```
 
 Handy metrics based on numbers above:


### PR DESCRIPTION
**Imported from [donnemartin/system-design-primer#260](https://github.com/donnemartin/system-design-primer/pull/260)**

Original author: @0bsearch

---

 - official SI prefix for microseconds
 - official IEEE prefixes for powers of 2 (#86)
