### PR TITLE
Update CHANGELOG and README for System Design Primer Update 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
 v0.0.1 – System Design Primer: Update Edition (Preview)
-Release Date: 2025-04-30
+Release Date: 2025-05-11
 
 🚀 Major Updates & New Features
-Updated the pastebin solution. 
 
-Serve the content in GitHub pages.
+- **Issue & PR migration**: Migrated all issues and pull requests to the new repo—merged active PRs, closed those older than three years as archived, and marked old issues as “not planned” to preserve history while allowing users to reopen them if they wish.
+- **Project board established**: To enable a clear view of project progress, see our [System Design Primer Content Update & Revamp](https://github.com/users/ido777/projects/1/views/1).
+- **Added [Discussions](https://github.com/ido777/system-design-primer-update/discussions)**: To enable a community driven effort, we will use discussions to share ideas, ask questions and get feedback.
+- **GitHub Pages deployment**: Easy navigation and styling via Pages.
+- **Solutions refactoring**: Refactored most solutions to comply with the new study guide.
+
 
 🔧 Refactoring
-Move the Readme main files to docs.
+Move the Readme main files to docs/en/design-glance.md.
 
-Added a new README.md file to docs to serve as a landing page for the repository (not the guide itself).
+Added a new README.md file to the repository to serve as a landing page for the repository (not the guide itself).
+
+Added a new Study Guide to be a new starting point. 
+The new study guide tries to explain the interview concepts in a way that is easy to understand and follow.
+
+Split the solution table into 2 pages one with questions the other with solutions.
 
 📑 Licensing Clarifications
 Original content remains under CC BY 4.0, with explicit attribution to the original author.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The world of software development has evolved dramatically since 2017. Today, sy
 
 - **Outdated Core Content**: The majority of the original material dates back to 2017. Foundational chapters on scaling, fault tolerance, and microservices were written before Kubernetes became ubiquitous.
 - **Generative AI Impact**: Emerging AI-driven patterns—from inference pipelines to LLM-powered observability—are not covered in the legacy primer. Incorporating these topics will keep the guide relevant.
+- - **Guide structure**: The structure is not optimal for learning. It is not easy to follow and understand the guide. People were asking for a better structure already from 2021 [here for example](https://github.com/donnemartin/system-design-primer/pull/598).
 - **Stagnant Maintenance**: Even minor fixes—typo corrections, link updates, and broken URL patches—have gone unaddressed for at least two years. Examples include [is this awesome repo no longer been updated?](https://github.com/donnemartin/system-design-primer/issues/840) that was opened at **Feb 2024** or [Indieflashblog link is dead](https://github.com/donnemartin/system-design-primer/issues/501) that was opened at **Jan 2021**.
 
 ### 3. Community Call to Action
@@ -52,17 +53,18 @@ These capabilities will help learners deepen their understanding and kickstart r
 - **Issue & PR migration**: Migrated all issues and pull requests to the new repo—merged active PRs, closed those older than three years as archived, and marked old issues as “not planned” to preserve history while allowing users to reopen them if they wish.
 - **Project board established**: To enable a clear view of project progress, see our [System Design Primer Content Update & Revamp](https://github.com/users/ido777/projects/1/views/1).
 - **Added [Discussions](https://github.com/ido777/system-design-primer-update/discussions)**: To enable a community driven effort, we will use discussions to share ideas, ask questions and get feedback.
+- **GitHub Pages deployment**: Easy navigation and styling via Pages.
+- **Solutions refactoring**: Refactored most solutions to comply with the new study guide.
 
 ### In Progress
 - **Content refactoring**: Monolithic README split into modular sections.
-- **Solutions modernization**: 
-- **GitHub Pages deployment**: Easy navigation and styling via Pages.
 - **Mermaid Diagrams**: Converting static images into editable flowcharts.
 
 ### Upcoming
 - **Translation overhaul**: Prototype AI‑assisted translation workflow.
 - **Fair‑use excerpts**: Add curated snippets from key texts (Alex Xu, Brendan Burns).
 - **CI/CD for quality**: Automate grammar checks, link validations, and draft translations.
+- **Solutions modernization**: Update solutions to comply with the new technologies and trends.
 - **Interactive course launch**: Alpha release of an AI‑guided system design simulator.
 
 ## ❓ Open Questions

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,6 +12,7 @@ The world of software development has evolved dramatically since 2017. Today, sy
 
 - **Outdated Core Content**: The majority of the original material dates back to 2017. Foundational chapters on scaling, fault tolerance, and microservices were written before Kubernetes became ubiquitous.
 - **Generative AI Impact**: Emerging AI-driven patterns—from inference pipelines to LLM-powered observability—are not covered in the legacy primer. Incorporating these topics will keep the guide relevant.
+- **Guide structure**: The structure is not optimal for learning. It is not easy to follow and understand the guide. People were asking for a better structure already from 2021 [here for example](https://github.com/donnemartin/system-design-primer/pull/598).
 - **Stagnant Maintenance**: Even minor fixes—typo corrections, link updates, and broken URL patches—have gone unaddressed for at least two years. Examples include [is this awesome repo no longer been updated?](https://github.com/donnemartin/system-design-primer/issues/840) that was opened at **Feb 2024** or [Indieflashblog link is dead](https://github.com/donnemartin/system-design-primer/issues/501) that was opened at **Jan 2021**.
 
 ### 3. Community Call to Action


### PR DESCRIPTION
Update CHANGELOG and README for System Design Primer Update: Revamped structure and added new features

- Updated release date in CHANGELOG to 2025-05-11.
- Migrated issues and pull requests to the new repository, merging active PRs and archiving older ones.
- Established a project board for tracking progress and added discussions for community engagement.
- Implemented GitHub Pages for improved navigation and styling.
- Refactored solutions to align with the new study guide, which now offers a clearer explanation of interview concepts.
- Enhanced README.md to address outdated content and improve guide structure for better learning experience.
